### PR TITLE
use dedicated backend and model

### DIFF
--- a/gptel-quick.el
+++ b/gptel-quick.el
@@ -68,6 +68,13 @@
 
 This can include other regions, buffers or files added by
 `gptel-add'.")
+(defvar gptel-quick-backend nil
+  "Set `gptel-quick-backend' to use a dedicated model. Require
+`gptel-quick-model' to be configured.")
+(defvar gptel-quick-model nil
+  "Set `gptel-quick-model' to use a dedicated model. Must be one of
+`gptel-quick-backend''s models. Require `gptel-quick-backend' to
+be configured.")
 
 ;;;###autoload
 (defun gptel-quick (query-text &optional count)
@@ -88,7 +95,9 @@ word count of the response."
          (gptel-max-tokens (floor (+ (sqrt (length query-text))
                                      (* count 2.5))))
          (gptel-use-curl)
-         (gptel-use-context (and gptel-quick-use-context 'system)))
+         (gptel-use-context (and gptel-quick-use-context 'system))
+         (gptel-backend (or gptel-quick-backend gptel-backend))
+         (gptel-model (or gptel-quick-model gptel-model)))
     (gptel-request query-text
       :system (format "Explain in %d words or fewer." count)
       :context (list query-text count

--- a/gptel-quick.el
+++ b/gptel-quick.el
@@ -91,6 +91,10 @@ word count of the response."
            (mapconcat #'identity (pdf-view-active-region-text) "\n\n"))
           (t (thing-at-point 'sexp)))
          current-prefix-arg))
+
+  (when (xor gptel-quick-backend gptel-quick-model)
+    (error "gptel-quick-backend and gptel-quick-model must be both set or unset"))
+
   (let* ((count (or count gptel-quick-word-count))
          (gptel-max-tokens (floor (+ (sqrt (length query-text))
                                      (* count 2.5))))


### PR DESCRIPTION
### Problem
`gptel-quick` uses the current `gptel-model` (can be set in `gptel-menu`), but I want to use a dedicated model for `gptel-quick` only. I know the model can be saved by selecting "for this buffer" in `gptel-menu`, but it is not convenient in this case.

### Solution
In this PR, add variables `gptel-quick-backend` and `gptel-quick-model`, they must be both set or unset. When both set, `gptel-quick` will use the dedicated model.

### Usage
```elisp
(defvar gptel--ollama
  (gptel-make-ollama "Ollama"
    :host "localhost:11434"
    :stream t
    :models '("llama3:latest")))

(use-package gptel-quick
  :vc (gptel-quick :url "https://github.com/karthink/gptel-quick.git")
  :config
  (message "gptel-quick is loaded")
  (setq gptel-quick-backend gptel--ollama
        gptel-quick-model "llama3:latest")
  :bind ( :map embark-general-map
          ("?" . gptel-quick)))
```