### PR TITLE
fix: Respect global `gptel-use-curl' instead of forcing url.el

### DIFF
--- a/gptel-quick.el
+++ b/gptel-quick.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2024  Karthik Chikmagalur
 
-;; Author: Karthik Chikmagalur(require 'gptel) <karthikchikmagalur@gmail.com>
+;; Author: Karthik Chikmagalur <karthikchikmagalur@gmail.com>
 ;; Version: 0.0.5
 ;; Package-Requires: ((emacs "28.1") (compat "29.1.4.1") (gptel "0.8.0"))
 ;; Keywords: convenience, help, extensions
@@ -119,7 +119,6 @@ word count of the response."
   (let* ((count (or count gptel-quick-word-count))
          (gptel-max-tokens (floor (+ (sqrt (length query-text))
                                      (* count 2.5))))
-         (gptel-use-curl)
          (gptel-use-context (and gptel-quick-use-context 'system))
          (gptel-backend (or gptel-quick-backend gptel-backend))
          (gptel-model (or gptel-quick-model gptel-model)))


### PR DESCRIPTION
## Summary

`gptel-quick` unconditionally binds `gptel-use-curl` to nil via
`(gptel-use-curl)` inside its main `let*`, which forces every
request through Emacs' built-in url.el even when the user has
`gptel-use-curl` set to `t` globally.

This silently disables every curl-specific option, most notably
`gptel-curl-extra-args` (commonly used for proxy configuration).
Users with a working proxy setup in regular gptel see
`gptel-quick` fail with connection errors / 403 from gated
regions, while `gptel-send` works fine — with no signal as to why.

## Change

One line removed. `gptel-quick` now uses whatever HTTP backend
the rest of gptel uses.

## Backward compatibility

For anyone who explicitly preferred the url.el path (faster start
when curl isn't cached in disk cache, no process spawn), they can
still get that behavior by setting `(setq gptel-use-curl nil)`
globally. No defcustom added since this is what gptel itself
already exposes.

## Repro before this change

1. Set up `gptel-make-anthropic` (or any backend) with `:curl-args
   '("--proxy" "...")` or via `gptel-proxy`.
2. Verify `gptel-send` works through the proxy.
3. Call `gptel-quick` — request goes direct, bypassing the proxy.